### PR TITLE
Restrict commercial invoice visibility

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -20,7 +20,7 @@
     'version': '16.0.0.1',
 
     # any module necessary for this one to work correctly
-    'depends': ['sale'], 
+    'depends': ['sale', 'account'],
 
     # always loaded
     'data': [

--- a/security/security_rules.xml
+++ b/security/security_rules.xml
@@ -14,4 +14,18 @@
         <!-- Asegurar que se cree el External ID -->
         <field name="active" eval="True"/>
     </record>
+
+    <!-- Facturas visibles solo para el comercial asignado al cliente -->
+    <record id="wsramsons_invoice_salesman_rule" model="ir.rule">
+        <field name="name">[wsramsons] Facturas: Restricción por comercial</field>
+        <field name="model_id" ref="account.model_account_move"/>
+        <field name="domain_force">[('partner_id.user_id', '=', user.id)]</field>
+        <field name="groups" eval="[(4, ref('wsramsons.group_comercial'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+        <field name="global" eval="False"/>
+        <field name="active" eval="True"/>
+    </record>
 </odoo>


### PR DESCRIPTION
## Summary
- show only a commercial's own customers' invoices
- declare dependency on account module

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc0f86403c8323a4468f73901fbe6f