### PR TITLE
Fix invoice search view inheritance to valid XMLID

### DIFF
--- a/views/invoice.xml
+++ b/views/invoice.xml
@@ -78,49 +78,26 @@
     </record>
 	
 	<!--grupo comercial siempre activo filtro mis facturas-->
-	<record id="view_move_search_restriccion" model="ir.ui.view">
-		<field name="name">account.move.search.restriccion</field>
-		<field name="model">account.move</field>
-		<!-- Usar el XMLID correcto -->
-		<field name="inherit_id" ref="account.view_move_search"/>
-		<field name="arch" type="xml">
+        <record id="view_move_search_restriccion" model="ir.ui.view">
+                <field name="name">account.move.search.restriccion</field>
+                <field name="model">account.move</field>
+                <field name="inherit_id" ref="account.view_account_move_filter"/>
+                <field name="arch" type="xml">
 
-			<!-- Activa el filtro "Mis facturas" al abrir -->
-			<xpath expr="//search" position="attributes">
-				<attribute name="context">{'search_default_my_invoices': 1}</attribute>
-			</xpath>
+                        <!-- Activa el filtro "Mis facturas" al abrir -->
+                        <xpath expr="//search" position="attributes">
+                                <attribute name="context">{'search_default_my_invoices': 1}</attribute>
+                        </xpath>
 
-			<!-- Oculta todos los filtros excepto “Mis facturas” -->
-			<xpath expr="//filter[@name!='my_invoices']" position="attributes">
-				<attribute name="groups">base.group_no_one</attribute>
-			</xpath>
-		</field>
+                        <!-- Oculta todos los filtros excepto "Mis facturas" -->
+                        <xpath expr="//filter[@name!='my_invoices']" position="attributes">
+                                <attribute name="groups">base.group_no_one</attribute>
+                        </xpath>
+                </field>
 
-		<!-- Solo aplicable al grupo “restricción por comercial” -->
-		<field name="groups_id" eval="[(4, ref('wsramsons.group_comercial'))]"/>
-	</record>
-
-
-	<record id="view_move_search_restriccion" model="ir.ui.view">
-		<field name="name">account.move.search.restriccion</field>
-		<field name="model">account.move</field>
-		<field name="inherit_id" ref="account.view_account_invoice_filter"/>
-		<field name="arch" type="xml">
-
-			<!-- Activa el filtro "Mis facturas" al abrir -->
-			<xpath expr="//search" position="attributes">
-				<attribute name="context">{'search_default_myinvoices': 1}</attribute>
-			</xpath>
-
-			<!-- Oculta todos los filtros excepto "Mis facturas" -->
-			<xpath expr="//filter[@name!='myinvoices']" position="attributes">
-				<attribute name="groups">base.group_no_one</attribute>
-			</xpath>
-		</field>
-
-		<!-- Aplica solo a los usuarios del grupo restricción por comercial -->
-		<field name="groups_id" eval="[(4, ref('wsramsons.group_comercial'))]"/>
-	</record>
+                <!-- Aplica solo a los usuarios del grupo restricción por comercial -->
+                <field name="groups_id" eval="[(4, ref('wsramsons.group_comercial'))]"/>
+        </record>
 
 </odoo>
 


### PR DESCRIPTION
## Summary
- fix invoice search view by inheriting from `account.view_account_move_filter`
- default 'Mis facturas' filter and hide others for commercial group

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bc7ef1ac888323aed0d9d74a738c7b