### PR TITLE
Restringir permisos comerciales con reglas de registro

### DIFF
--- a/security/security_rules.xml
+++ b/security/security_rules.xml
@@ -26,6 +26,10 @@
         <field name="model_id" ref="sale.model_sale_order"/>
         <field name="domain_force">['|', ('partner_id.user_id', '=', user.id), ('partner_id.parent_id.user_id', '=', user.id)]</field>
         <field name="groups" eval="[(4, ref('wsramsons.group_comercial'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
     <record id="wsramsons_account_move_user_rule" model="ir.rule">
@@ -33,6 +37,10 @@
         <field name="model_id" ref="account.model_account_move"/>
         <field name="domain_force">['|', ('partner_id.user_id', '=', user.id), ('partner_id.parent_id.user_id', '=', user.id)]</field>
         <field name="groups" eval="[(4, ref('wsramsons.group_comercial'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
     </record>
 
 </odoo>


### PR DESCRIPTION
## Summary
- elimina los bloqueos en los modelos de pedidos y facturas para dejar solo sus personalizaciones funcionales
- ajusta las reglas `wsramsons_sale_order_user_rule` y `wsramsons_account_move_user_rule` otorgando únicamente lectura al grupo comercial

## Testing
- python3 -m compileall wsramsons

------
https://chatgpt.com/codex/tasks/task_e_68c9458bd04c8323aef7376782ece0ea