### PR TITLE
Aplicar bloqueos comerciales en pedidos y facturas

### DIFF
--- a/models/sale_order.py
+++ b/models/sale_order.py
@@ -1,7 +1,31 @@
 from odoo import api, models
+from odoo.exceptions import AccessError
 
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
+
+    def _is_commercial_user(self):
+        return self.env.user.has_group('wsramsons.group_comercial')
+
+    @staticmethod
+    def _is_allowed_chatter_update(vals):
+        if not vals:
+            return True
+
+        allowed_prefixes = ('message_', 'activity_')
+        allowed_fields = {'message_follower_ids', 'message_ids', 'activity_ids'}
+
+        for field_name in vals.keys():
+            if field_name in allowed_fields:
+                continue
+            if field_name.startswith(allowed_prefixes):
+                continue
+            return False
+        return True
+
+    def _check_commercial_block(self, message):
+        if self._is_commercial_user():
+            raise AccessError(message)
 
     ''' 
     def _prepare_invoice(self):
@@ -16,6 +40,26 @@ class SaleOrder(models.Model):
         if 'narration' in invoice_vals:
             invoice_vals['narration'] = ''  # O puedes asignarle otro valor si lo deseas
         return invoice_vals
+
+    def write(self, vals):
+        if self._is_commercial_user() and not self._is_allowed_chatter_update(vals):
+            self._check_commercial_block("No tienes permisos para modificar presupuestos.")
+        return super().write(vals)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        if self.env.user.has_group('wsramsons.group_comercial'):
+            raise AccessError("No tienes permisos para crear presupuestos.")
+        return super().create(vals_list)
+
+    def unlink(self):
+        if self._is_commercial_user():
+            self._check_commercial_block("No tienes permisos para eliminar presupuestos.")
+        return super().unlink()
+
+    def action_set_to_draft(self):
+        self._check_commercial_block("No tienes permisos para reabrir presupuestos.")
+        return super().action_set_to_draft()
         
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'


### PR DESCRIPTION
## Summary
- impide que los usuarios comerciales creen, modifiquen o reabran presupuestos salvo operaciones del chatter
- bloquea a los comerciales de crear, modificar, reabrir o romper conciliaciones en facturas y sus apuntes, permitiéndoles únicamente actividades y mensajes
- deja las reglas de registro de pedidos y facturas sin overrides de permisos para que no interfieran con otras reglas

## Testing
- python3 -m compileall wsramsons

------
https://chatgpt.com/codex/tasks/task_e_68c9458bd04c8323aef7376782ece0ea