### PR TITLE
Prevent commercial users from deleting attachments

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,3 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from . import sale_order, account, payment, partner, product, product_category
+from . import sale_order
+from . import account
+from . import payment
+from . import partner
+from . import product
+from . import product_category
+from . import ir_attachment

--- a/models/ir_attachment.py
+++ b/models/ir_attachment.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models
+from odoo.exceptions import AccessError
+
+
+class IrAttachment(models.Model):
+    _inherit = "ir.attachment"
+
+    def unlink(self):
+        if self.env.user.has_group("wsramsons.group_comercial"):
+            raise AccessError("No tienes permisos para eliminar adjuntos.")
+        return super().unlink()


### PR DESCRIPTION
## Summary
- add an ir.attachment override to prevent users in wsramsons.group_comercial from deleting attachments
- load the new model in the module initialization

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c981a4f1388323853018d882bcefa9